### PR TITLE
Remove build alias and note

### DIFF
--- a/24rc-testing.md
+++ b/24rc-testing.md
@@ -38,9 +38,6 @@ To ensure we build in sqlite and gui support, pass the following options when co
 ```shell
 ./autogen.sh
 ./configure --with-gui=yes --with-sqlite=yes --enable-suppress-external-warnings
-# nproc does not exist on macOS so we create an alias for it if necessary
-if ! command -v nproc &> /dev/null; then alias nproc="sysctl -n hw.physicalcpu"; fi  
-make -j "$(($(nproc)+1))"
 ```
 
 For more information on compiling from source, here are some guides to compile Bitcoin Core for [UNIX/Linux](https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md), [macOS](https://github.com/bitcoin/bitcoin/blob/master/doc/build-osx.md), [Windows](https://github.com/bitcoin/bitcoin/blob/master/doc/build-windows.md), [FreeBSD](https://github.com/bitcoin/bitcoin/blob/master/doc/build-freebsd.md), [NetBSD](https://github.com/bitcoin/bitcoin/blob/master/doc/build-netbsd.md), and [OpenBSD](https://github.com/bitcoin/bitcoin/blob/master/doc/build-openbsd.md).


### PR DESCRIPTION
Remove the alias and note on actual building from the section on compiling the release candidate.

The note added here is really a hint towards the configuration we want to do, but it is not complete. These steps as outlined won't work for all systems, there's extra configuration needed say for example on the bsd's. Some user's won't actually be able to build with these steps.

So, let the user read the build docs if they're going to go on the adventure of compiling core, let them bathe in the build system and be reborn/